### PR TITLE
Update pp.c

### DIFF
--- a/src/pp.c
+++ b/src/pp.c
@@ -12,6 +12,8 @@
 #include <getopt.h>
 #include <ctype.h>
 #include <signal.h>
+#include <locale.h>
+#include <windows.h>
 
 #include "mpz_int128.h"
 
@@ -679,6 +681,10 @@ static void catch_int (int signum)
 
 int main (int argc, char *argv[])
 {
+  /* Force UTF-8 encoding in windows terminal. If not set it messes upp passwords
+  containing åäö and maybe other special characters. */
+  SetConsoleOutputCP(65001)
+    
   mpz_t pw_ks_pos[OUT_LEN_MAX + 1];
   mpz_t pw_ks_cnt[OUT_LEN_MAX + 1];
 


### PR DESCRIPTION
We are running Hashtopolis and some tasks with Prince activated. We have noticed that wordlists encoded in UTF8 create problems with characters such as åäö (swedish). The linux executable works fine but the windows executable, pp64.exe, does not output the characters correctly, this in turn means that all the agents running Hashtopolis in Windows will not be able to crack passwords with åäö.

Forcing UTF-8 during compile seemed to solve the problem, not sure if there is a mor elegant solution.